### PR TITLE
Develop

### DIFF
--- a/custom_components/usgs_quakes/config_flow.py
+++ b/custom_components/usgs_quakes/config_flow.py
@@ -1,19 +1,15 @@
 from homeassistant import config_entries
 import voluptuous as vol
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
-from homeassistant.helpers.selector import selector
 
 from .const import (
     DOMAIN,
+    DEFAULT_RADIUS_IN_KM,
+    DEFAULT_MINIMUM_MAGNITUDE,
     CONF_FEED_TYPE,
     CONF_MINIMUM_MAGNITUDE,
     VALID_FEED_TYPES,
-    DEFAULT_RADIUS_IN_KM,
-    DEFAULT_MINIMUM_MAGNITUDE,
-    FEED_TYPE_FRIENDLY_NAMES,
-    FRIENDLY_NAME_TO_FEED_TYPE,
 )
-
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for USGS Quakes."""
@@ -21,29 +17,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
     async def async_step_user(self, user_input=None):
-        if user_input is not None:
-            # Map friendly name to internal key
-            return self.async_create_entry(
-                title="USGS Quakes",
-                data={
-                    CONF_FEED_TYPE: FRIENDLY_NAME_TO_FEED_TYPE[user_input["feed_type_friendly"]],
-                    CONF_LATITUDE: user_input[CONF_LATITUDE],
-                    CONF_LONGITUDE: user_input[CONF_LONGITUDE],
-                    CONF_RADIUS: user_input[CONF_RADIUS],
-                    CONF_MINIMUM_MAGNITUDE: user_input[CONF_MINIMUM_MAGNITUDE],
-                }
-            )
+        # 🚫 Prevent multiple instances
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
 
-        # Use friendly names in selector
-        feed_friendly_names = list(FEED_TYPE_FRIENDLY_NAMES.values())
+        if user_input is not None:
+            return self.async_create_entry(title="USGS Quakes", data=user_input)
 
         schema = vol.Schema({
-            vol.Required("feed_type_friendly", default=feed_friendly_names[0]): selector({
-                "select": {
-                    "options": feed_friendly_names,
-                    "mode": "dropdown"
-                }
-            }),
+            vol.Required(CONF_FEED_TYPE): vol.In(VALID_FEED_TYPES),
             vol.Required(CONF_LATITUDE, default=self.hass.config.latitude): vol.Coerce(float),
             vol.Required(CONF_LONGITUDE, default=self.hass.config.longitude): vol.Coerce(float),
             vol.Required(CONF_RADIUS, default=DEFAULT_RADIUS_IN_KM): vol.Coerce(float),

--- a/custom_components/usgs_quakes/manifest.json
+++ b/custom_components/usgs_quakes/manifest.json
@@ -6,7 +6,7 @@
   "dependencies": [],
   "documentation": "https://github.com/Geek-MD/USGS_Quakes",
   "requirements": ["aio-geojson-usgs-earthquakes==0.3"],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "iot_class": "cloud_polling",
   "translations": ["en", "es"]
 }

--- a/custom_components/usgs_quakes/translations/en.json
+++ b/custom_components/usgs_quakes/translations/en.json
@@ -13,6 +13,9 @@
       "longitude": "Longitude",
       "radius": "Radius (km)",
       "minimum_magnitude": "Minimum Magnitude"
+    },
+    "error": {
+      "single_instance_allowed": "Only a single instance is allowed."
     }
   }
 }

--- a/custom_components/usgs_quakes/translations/es.json
+++ b/custom_components/usgs_quakes/translations/es.json
@@ -1,10 +1,10 @@
 {
-  "title": "Terremotos USGS",
+  "title": "USGS Quakes",
   "config": {
     "step": {
       "user": {
-        "title": "Configurar Terremotos USGS",
-        "description": "Selecciona el feed de terremotos del USGS y configura la ubicación."
+        "title": "Configurar USGS Quakes",
+        "description": "Selecciona el feed de terremotos de USGS y la configuración de ubicación."
       }
     },
     "data": {
@@ -13,6 +13,9 @@
       "longitude": "Longitud",
       "radius": "Radio (km)",
       "minimum_magnitude": "Magnitud Mínima"
+    },
+    "error": {
+      "single_instance_allowed": "Solo se permite una instancia de esta integración."
     }
   }
 }

--- a/custom_components/usgs_quakes/translations/strings.json
+++ b/custom_components/usgs_quakes/translations/strings.json
@@ -3,11 +3,12 @@
   "config": {
     "step": {
       "user": {
-        "title": "Configure USGS Quakes"
+        "title": "Configure USGS Quakes",
+        "description": "Select the USGS earthquake feed and location settings."
       }
     },
-    "abort": {
-      "single_instance_allowed": "Only a single instance is allowed.",
+    "error": {
+      "single_instance_allowed": "Only a single instance is allowed."
     }
   }
 }

--- a/custom_components/usgs_quakes/translations/strings.json
+++ b/custom_components/usgs_quakes/translations/strings.json
@@ -7,7 +7,7 @@
       }
     },
     "abort": {
-      "single_instance_allowed": "Only a single instance is allowed."
+      "single_instance_allowed": "Only a single instance is allowed.",
     }
   }
 }


### PR DESCRIPTION
## 📦 v1.0.1

**Released:** 2025-07-08

### ✅ Improvements

- The integration now allows only a **single instance** to be configured, preventing duplicate setups.
- Added **localized error messages** in both English and Spanish when a second instance is attempted.
- Updated `strings.json`, `en.json`, and `es.json` with friendly error labels:
  - `"Only a single instance is allowed."`
  - `"Solo se permite una instancia de esta integración."`

### 🛠️ Technical Changes

- Implemented a validation check in `config_flow.py` using `_async_current_entries()`.
- Extended translation files with `"single_instance_allowed"` error key.